### PR TITLE
Add sample prompts

### DIFF
--- a/src/mcp_server_gravatar/gravatar.py
+++ b/src/mcp_server_gravatar/gravatar.py
@@ -20,8 +20,13 @@ def register_resources(mcp: FastMCP):
     avatar_tools.register_resources(mcp)
 
 
+def register_prompts(mcp: FastMCP):
+    profile_tools.register_prompts(mcp)
+
+
 def serve():
     # Run the MCP server over stdio
     register_tools(mcp)
     register_resources(mcp)
+    register_prompts(mcp)
     mcp.run(transport="stdio")

--- a/src/mcp_server_gravatar/tools/profile_tools.py
+++ b/src/mcp_server_gravatar/tools/profile_tools.py
@@ -1,6 +1,7 @@
 import json
 from typing import overload, Literal, Union, Any, Protocol
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP, Context
+from mcp.server.fastmcp.prompts.base import UserMessage
 
 
 class ProfileTools:
@@ -219,3 +220,15 @@ class ProfileTools:
         async def get_profile(email: str) -> str:
             profile = await self.get_profile_by_email(email)
             return json.dumps(profile)
+
+    def register_prompts(self, mcp: FastMCP):
+        @mcp.prompt()
+        def summarize_gravatar_profile(email: str) -> str:
+            """
+            Prompt that instructs the model to summarize a Gravatar profile.
+            """
+            return [
+                UserMessage(
+                    f"You are an assistant that summarizes Gravatar profiles.  Use data from the profile at 'profiles://email/{email}'.  If the profile contains `verified_accounts`, visit the `url` for each account.  Include what you find there in your summary. "
+                )
+            ]

--- a/src/mcp_server_gravatar/tools/profile_tools.py
+++ b/src/mcp_server_gravatar/tools/profile_tools.py
@@ -2,7 +2,7 @@ import json
 import httpx
 from typing import overload, Literal, Union, Any, Protocol
 from mcp.server.fastmcp import FastMCP, Context
-from mcp.server.fastmcp.prompts.base import UserMessage
+from mcp.server.fastmcp.prompts.base import Message, UserMessage
 
 
 class ProfileTools:
@@ -225,7 +225,7 @@ class ProfileTools:
     def register_prompts(self, mcp: FastMCP):
 
         @mcp.prompt()
-        async def summarize_gravatar_profile(email: str, ctx: Context) -> list[UserMessage]:
+        async def summarize_gravatar_profile(email: str, ctx: Context) -> list[Message]:
             """
             Read a Gravatar profile via MCP resource and summarize it
             """
@@ -240,8 +240,9 @@ class ProfileTools:
             else:
                 profile_json = contents[0].content
 
+            profile_data = json.loads(profile_json)
             # Build messages for the model
             return [
                 UserMessage(
-                    f"You are an assistant that summarizes Gravatar profiles. Here is the profile JSON data:\n{profile_json}\n\nPlease provide a one-paragraph, professional summary of this profile, including display name, biography, location, and any links."),
+                    f"You are an assistant that summarizes Gravatar profiles. Here is the profile JSON data:\n{profile_data}\n\nPlease provide a one-paragraph, professional summary of this profile, including display name, biography, location, and any links."),
             ]

--- a/src/mcp_server_gravatar/tools/profile_tools.py
+++ b/src/mcp_server_gravatar/tools/profile_tools.py
@@ -203,16 +203,6 @@ class ProfileTools:
         ) -> Union[str, bool, int, list[dict[str, Any]], dict[str, Any]]:
             return await self.get_profile_field_with_email(email, field)
 
-        @mcp.tool()
-        async def visit_verified_account_url(url: str) -> str:
-            """
-            Fetches the raw text content at the given URL.
-            """
-            async with httpx.AsyncClient(verify=False) as client_http:
-                response = await client_http.get(url)
-                response.raise_for_status()
-                return response.text
-
     def register_resources(self, mcp: FastMCP):
         @mcp.resource(
             uri="profiles://profileIdentifier/{profileIdentifier}",
@@ -272,8 +262,6 @@ class ProfileTools:
                     f"You are a professional assistant skilled at writing concise, engaging summaries of user profiles.\n\n"
                     f"First, call the get_profile_by_email tool with argument email='{email}' to fetch the raw profile JSON.\n"
                     f"Next, extract the fields display_name, location, description, job_title, company, timezone, languages, interests, and verified_accounts.\n"
-                    f"If any verfied_account entries are listed, extract the `url` from each entry.  Call the `visit_verified_account_url` tool to fetch that page’s contents, \n"
-                    f"and include those contents when crafting your summary.\n"
                     f"Finally, produce a one- to two-paragraph professional summary, using natural, flowing sentences without bullet points."
                 ),
             ]

--- a/src/mcp_server_gravatar/tools/profile_tools.py
+++ b/src/mcp_server_gravatar/tools/profile_tools.py
@@ -203,6 +203,16 @@ class ProfileTools:
         ) -> Union[str, bool, int, list[dict[str, Any]], dict[str, Any]]:
             return await self.get_profile_field_with_email(email, field)
 
+        @mcp.tool()
+        async def visit_verified_account_url(url: str) -> str:
+            """
+            Fetches the raw text content at the given URL.
+            """
+            async with httpx.AsyncClient(verify=False) as client_http:
+                response = await client_http.get(url)
+                response.raise_for_status()
+                return response.text
+
     def register_resources(self, mcp: FastMCP):
         @mcp.resource(
             uri="profiles://profileIdentifier/{profileIdentifier}",
@@ -262,6 +272,8 @@ class ProfileTools:
                     f"You are a professional assistant skilled at writing concise, engaging summaries of user profiles.\n\n"
                     f"First, call the get_profile_by_email tool with argument email='{email}' to fetch the raw profile JSON.\n"
                     f"Next, extract the fields display_name, location, description, job_title, company, timezone, languages, interests, and verified_accounts.\n"
+                    f"If any verfied_account entries are listed, extract the `url` from each entry.  Call the `visit_verified_account_url` tool to fetch that page’s contents, \n"
+                    f"and include those contents when crafting your summary.\n"
                     f"Finally, produce a one- to two-paragraph professional summary, using natural, flowing sentences without bullet points."
                 ),
             ]

--- a/src/mcp_server_gravatar/tools/profile_tools.py
+++ b/src/mcp_server_gravatar/tools/profile_tools.py
@@ -245,7 +245,11 @@ class ProfileTools:
             # Build messages for the model
             return [
                 UserMessage(
-                    f"You are an assistant that summarizes Gravatar profiles. Here is the profile JSON data:\n{profile_data}\n\nPlease provide a one-paragraph, professional summary of this profile, including display name, biography, location, and any links."),
+                    f"You are a professional assistant skilled at writing concise, engaging summaries of user profiles.\n\n"
+                    f"Here is the profile JSON data:\n{profile_data}\n\n"
+                    f"Next, extract the fields display_name, location, description, job_title, company, timezone, languages, interests, and verified_accounts.\n"
+                    f"Finally, produce a one- to two-paragraph professional summary, using natural, flowing sentences without bullet points."
+                )
             ]
 
         @mcp.prompt()
@@ -255,5 +259,9 @@ class ProfileTools:
             """
             return [
                 UserMessage(
-                    f"You are an assistant that summarizes Gravatar profiles. Fetch the Gravatar Profile for this email address:\n{email}\n\nUsing that profile, please provide a one-paragraph, professional summary of this profile, including display name, biography, location, and any links."),
+                    f"You are a professional assistant skilled at writing concise, engaging summaries of user profiles.\n\n"
+                    f"First, call the get_profile_by_email tool with argument email='{email}' to fetch the raw profile JSON.\n"
+                    f"Next, extract the fields display_name, location, description, job_title, company, timezone, languages, interests, and verified_accounts.\n"
+                    f"Finally, produce a one- to two-paragraph professional summary, using natural, flowing sentences without bullet points."
+                ),
             ]

--- a/src/mcp_server_gravatar/tools/profile_tools.py
+++ b/src/mcp_server_gravatar/tools/profile_tools.py
@@ -209,7 +209,7 @@ class ProfileTools:
             Fetches the raw text content at the given URL.
             """
             async with httpx.AsyncClient(verify=False) as client_http:
-                response = await client_http.get(url, follow_redirects=True)
+                response = await client_http.get(url)
                 response.raise_for_status()
                 return response.text
 

--- a/src/mcp_server_gravatar/tools/profile_tools.py
+++ b/src/mcp_server_gravatar/tools/profile_tools.py
@@ -1,4 +1,5 @@
 import json
+import httpx
 from typing import overload, Literal, Union, Any, Protocol
 from mcp.server.fastmcp import FastMCP, Context
 from mcp.server.fastmcp.prompts.base import UserMessage
@@ -229,6 +230,6 @@ class ProfileTools:
             """
             return [
                 UserMessage(
-                    f"You are an assistant that summarizes Gravatar profiles.  Use data from the profile at 'profiles://email/{email}'.  If the profile contains `verified_accounts`, visit the `url` for each account.  Include what you find there in your summary. "
+                    f"You are an assistant that summarizes Gravatar profiles.  Use data from the profile at 'profiles://email/{email}'.  The summary must be professional and no more than one paragraph in length."
                 )
             ]

--- a/src/mcp_server_gravatar/tools/profile_tools.py
+++ b/src/mcp_server_gravatar/tools/profile_tools.py
@@ -209,7 +209,7 @@ class ProfileTools:
             Fetches the raw text content at the given URL.
             """
             async with httpx.AsyncClient(verify=False) as client_http:
-                response = await client_http.get(url)
+                response = await client_http.get(url, follow_redirects=True)
                 response.raise_for_status()
                 return response.text
 

--- a/src/mcp_server_gravatar/tools/profile_tools.py
+++ b/src/mcp_server_gravatar/tools/profile_tools.py
@@ -228,6 +228,7 @@ class ProfileTools:
         async def summarize_gravatar_profile(email: str, ctx: Context) -> list[Message]:
             """
             Read a Gravatar profile via MCP resource and summarize it
+            Note: FastMCP doesn't currently support passing the context to a prompt (https://github.com/jlowin/fastmcp/issues/134)
             """
             # Log the start of the prompt execution
             await ctx.debug(f"summarize_gravatar_profile called with email={email}")

--- a/src/mcp_server_gravatar/tools/profile_tools.py
+++ b/src/mcp_server_gravatar/tools/profile_tools.py
@@ -247,3 +247,13 @@ class ProfileTools:
                 UserMessage(
                     f"You are an assistant that summarizes Gravatar profiles. Here is the profile JSON data:\n{profile_data}\n\nPlease provide a one-paragraph, professional summary of this profile, including display name, biography, location, and any links."),
             ]
+
+        @mcp.prompt()
+        async def summarize_gravatar_profile_via_tool(email: str) -> list[Message]:
+            """
+            Read a Gravatar profile using the get_profile tool and summarize it
+            """
+            return [
+                UserMessage(
+                    f"You are an assistant that summarizes Gravatar profiles. Fetch the Gravatar Profile for this email address:\n{email}\n\nUsing that profile, please provide a one-paragraph, professional summary of this profile, including display name, biography, location, and any links."),
+            ]


### PR DESCRIPTION
Adds sample prompts.

Note that the `summarize_gravatar_profile` prompt currently does not work, since FastMCP doesn't yet support passing the `Context` of the session into the prompt call.  (https://github.com/jlowin/fastmcp/issues/134)