### PR TITLE
Clean up MCP names

### DIFF
--- a/src/mcp_server_gravatar/tools/avatar_tools.py
+++ b/src/mcp_server_gravatar/tools/avatar_tools.py
@@ -149,35 +149,35 @@ class AvatarTools:
         return images
 
     def register_tools(self, mcp: FastMCP):
-        @mcp.tool(
-            name="get_avatar_by_id_as_image",
-            description="Fetch the avatar for a given id as an image"
-        )
+        @mcp.tool()
         async def get_avatar_by_id_as_image(hash: str) -> Image:
+            """
+            Fetch the avatar for a given id as an image.
+            """
             avatar = await self.get_avatar_by_id_as_image(hash)
             return avatar
 
-        @mcp.tool(
-            name="get_avatars",
-            description="Fetch all avatars"
-        )
+        @mcp.tool()
         async def get_avatars(selected_email_hash: str | None = None) -> list[dict[str, Any]]:
+            """
+            Fetch all avatars.
+            """
             avatars = await self.get_avatars(selected_email_hash)
             return avatars
 
-        @mcp.tool(
-            name="get_avatars_as_images",
-            description="Fetch all avatars as images"
-        )
+        @mcp.tool()
         async def get_avatars_as_images(selected_email_hash: str | None = None) -> list[Image]:
+            """
+            Fetch all avatars as images.
+            """
             avatars = await self.get_avatars_as_images(selected_email_hash)
             return avatars
 
-        @mcp.tool(
-            name="get_selected_avatar_as_image",
-            description="Fetch the selected avatar as an image"
-        )
+        @mcp.tool()
         async def get_selected_avatar_as_image(email: str | None = None) -> list[Image]:
+            """
+            Fetch the selected avatar as an image.
+            """
             return await self.get_selected_avatar_as_image(email)
 
     def register_resources(self, mcp: FastMCP):

--- a/src/mcp_server_gravatar/tools/avatar_tools.py
+++ b/src/mcp_server_gravatar/tools/avatar_tools.py
@@ -183,42 +183,45 @@ class AvatarTools:
     def register_resources(self, mcp: FastMCP):
         @mcp.resource(
             uri="avatar://avatar_identifier/{avatar_identifier}",
-            name="Get avatar for id",
-            description="Returns an avatar for a given id",
             mime_type="image/png"
         )
         async def get_avatar_by_id(avatar_identifier: str) -> bytes:
+            """
+            Returns an avatar for a given id.
+            """
             avatar = await self.get_avatar_by_id(avatar_identifier=avatar_identifier)
             return avatar
 
         @mcp.resource(
             uri="avatar://email/{email}",
-            name="Get avatar for email",
-            description="Returns an avatar for a given email address",
             mime_type="image/png"
         )
         async def get_avatar_by_email(email: str) -> bytes:
+            """
+            Returns an avatar for a given email address.
+            """
             avatar = await self.get_avatar_by_email(email)
             return avatar
 
         @mcp.resource(
             uri="avatars://me",
-            name="Get all avatars",
-            description="Returns the avatars object as json for the authenticated user",
             mime_type="application/json"
         )
         async def get_avatars() -> str:
+            """
+            Returns the avatars object as JSON for the authenticated user.
+            """
             avatars = await self.get_avatars()
             return json.dumps(avatars)
 
         @mcp.resource(
             uri="avatars://me/images/{index}",
-            name="Get avatars at index",
-            description="Returns an avatar of the authenticated user as an image with a given index",
             mime_type="image/png"
         )
         async def get_avatar_at_index(index: int) -> bytes:
-
+            """
+            Returns an avatar of the authenticated user as an image with a given index.
+            """
             avatars = await self.get_avatars()
             # Guard against invalid index
             if index < 0 or index >= len(avatars):

--- a/src/mcp_server_gravatar/tools/profile_tools.py
+++ b/src/mcp_server_gravatar/tools/profile_tools.py
@@ -172,38 +172,38 @@ class ProfileTools:
         """
         Register all profile-related tools with the MCP server.
         """
-        @mcp.tool(
-            name="get_profile_by_email",
-            description="Fetch a profile using an email address"
-        )
+        @mcp.tool()
         async def get_profile_by_email(email: str) -> dict[str, Any]:
+            """
+            Fetch a profile using an email address.
+            """
             return await self.get_profile_by_email(email)
 
-        @mcp.tool(
-            name="get_profile_by_hash",
-            description="Fetch a profile using the profile identifier of an email address"
-        )
+        @mcp.tool()
         async def get_profile_by_hash(hash: str) -> dict[str, Any]:
+            """
+            Fetch a profile using the profile identifier of an email address.
+            """
             return await self.get_profile_by_hash(hash)
 
-        @mcp.tool(
-            name="get_profile_field_with_hash",
-            description="Fetch a specific field from a Gravatar profile using a profile identifier."
-        )
+        @mcp.tool()
         async def get_profile_field_with_hash(
             profileIdentifier: str,
             field: ProfileField
         ) -> Union[str, bool, int, list[dict[str, Any]], dict[str, Any]]:
+            """
+            Fetch a specific field from a Gravatar profile using a profile identifier.
+            """
             return await self.get_profile_field_with_hash(profileIdentifier, field)
 
-        @mcp.tool(
-            name="get_profile_field_with_email",
-            description="Fetch a specific field from a Gravatar profile using the profile identifier of an email address"
-        )
+        @mcp.tool()
         async def get_profile_field_with_email(
             email: str,
             field: ProfileField
         ) -> Union[str, bool, int, list[dict[str, Any]], dict[str, Any]]:
+            """
+            Fetch a specific field from a Gravatar profile using the profile identifier of an email address.
+            """
             return await self.get_profile_field_with_email(email, field)
 
     def register_resources(self, mcp: FastMCP):

--- a/src/mcp_server_gravatar/tools/profile_tools.py
+++ b/src/mcp_server_gravatar/tools/profile_tools.py
@@ -209,19 +209,23 @@ class ProfileTools:
     def register_resources(self, mcp: FastMCP):
         @mcp.resource(
             uri="profiles://profileIdentifier/{profileIdentifier}",
-            name="Get Profile by ID",
-            description="Returns a profile object as json",
-            mime_type="application/json")
-        async def get_profile(profileIdentifier: str) -> str:
+            mime_type="application/json"
+        )
+        async def get_profile_by_id(profileIdentifier: str) -> str:
+            """
+            Returns a profile object as JSON.
+            """
             profile = await self.get_profile_by_hash(profileIdentifier)
             return json.dumps(profile)
 
         @mcp.resource(
             uri="profiles://email/{email}",
-            name="Get Profile by email",
-            description="Returns a profile object as json",
-            mime_type="application/json")
-        async def get_profile(email: str) -> str:
+            mime_type="application/json"
+        )
+        async def get_profile_by_email(email: str) -> str:
+            """
+            Returns a profile object as JSON.
+            """
             profile = await self.get_profile_by_email(email)
             return json.dumps(profile)
 


### PR DESCRIPTION
Many of the method decorators were explicitly setting the name and description.  This converts those decorators and methods to using implicit names and descriptions.